### PR TITLE
Support for "away" preset mode and "idle" action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.idea
+
 # C extensions
 *.so
 

--- a/custom_components/climate_group/manifest.json
+++ b/custom_components/climate_group/manifest.json
@@ -3,7 +3,7 @@
   "name": "Climate Group",
   "documentation": "https://github.com/daenny/climate_group",
   "dependencies": [],
-  "codeowners": ["@daenny"],
+  "codeowners": ["@daenny", "@b4dpxl"],
   "requirements": [],
   "homeassistant": "0.96.0"
 }

--- a/custom_components/climate_group/manifest.json
+++ b/custom_components/climate_group/manifest.json
@@ -3,7 +3,7 @@
   "name": "Climate Group",
   "documentation": "https://github.com/daenny/climate_group",
   "dependencies": [],
-  "codeowners": ["@daenny", "@b4dpxl"],
+  "codeowners": ["@daenny"],
   "requirements": [],
   "homeassistant": "0.96.0"
 }


### PR DESCRIPTION
With the generic_thermostat, the action was always being returned as heat, even when idle. There was no support for away preset mode either.