### PR TITLE
Add attribute with list of member entities

### DIFF
--- a/custom_components/climate_group/climate.py
+++ b/custom_components/climate_group/climate.py
@@ -210,6 +210,11 @@ class ClimateGroup(ClimateEntity):
         """No polling needed for a climate group."""
         return False
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes for the climate group."""
+        return {ATTR_ENTITY_ID: self._entity_ids}
+
     async def async_set_temperature(self, **kwargs):
         """Forward the turn_on command to all climate in the climate group."""
         data = {ATTR_ENTITY_ID: self._entity_ids}


### PR DESCRIPTION
This adds a new attribute `entity_id` with a list of the member climate entities of this climate group.

The method is simply copied from https://github.com/home-assistant/core/blob/dev/homeassistant/components/group/light.py#L189-L192.